### PR TITLE
fix: filter and discard data whose time is out real time range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-chart",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "main": "dist/index.js",
   "types": "dist/types/index.d.ts",
   "targets": {

--- a/src/MetricChart/index.tsx
+++ b/src/MetricChart/index.tsx
@@ -183,13 +183,15 @@ const MetricsChart = ({
           // transform data according to nullValue config
           const transformedData =
             nullValue === TransformNullValue.AS_ZERO
-              ? data.map(d => {
-                  if (d[1] !== null) {
+              ? data
+                  .filter(d => d[0] > queryOptions[0] && d[0] < queryOptions[1])
+                  .map(d => {
+                    if (d[1] !== null) {
+                      return d
+                    }
+                    d[1] = 0
                     return d
-                  }
-                  d[1] = 0
-                  return d
-                })
+                  })
               : data
 
           const d: QueryData = {
@@ -266,7 +268,7 @@ const MetricsChart = ({
           id="left"
           position={Position.Left}
           showOverlappingTicks
-          tickFormat={(v) => {
+          tickFormat={v => {
             let _unit = unit || 'none'
             if (toPrecisionUnits.includes(_unit) && v < 1) {
               return v.toPrecision(3)


### PR DESCRIPTION
The x-axis ticks are aligned, some response points may out of the exact time range we request, so the y-axis tick will be affected by these points.

![image](https://user-images.githubusercontent.com/34967660/191891894-56b5d8e1-d703-41a5-8d06-f16fed4260ff.png)
